### PR TITLE
Set Sync Operations as Default + Hide ID from User

### DIFF
--- a/pycernan/avro/v1.py
+++ b/pycernan/avro/v1.py
@@ -23,7 +23,7 @@ class Client(client.Client):
 
     VERSION = 1
 
-    def publish_blob(self, avro_blob, id=None, shard_by=None):
+    def publish_blob(self, avro_blob, sync=True, id=None, shard_by=None):
         """
             Publishes an length prefixed avro payload to a V1 Avro source.
 
@@ -46,13 +46,13 @@ class Client(client.Client):
 
 
             Kwargs:
-                id : int - Optional identifier for the payload.  If not None, then the publish
-                           will be treated as synchronous.  Blocking until Cernan ACKS the id.
+                sync : bool - Wait for acknowledgment that the payload has been published?  Default = True.
+                id : int - Optional identifier for the payload.
                 shard_by : hashable value - Used to allocate the payload into a downstream bucket
                            (order is only preserved between entries allocated to the same bucket).
         """
         version = self.VERSION
-        sync = 1 if id else 0
+        sync = 1 if sync else 0
         id = int(id) if id else _rand_u64()
         shard_by = _hash_u64(shard_by) if shard_by else _rand_u64()
         header = struct.pack(">LLQQ", version, sync, id, shard_by)

--- a/tests/unit/avro/test_v1.py
+++ b/tests/unit/avro/test_v1.py
@@ -49,7 +49,8 @@ def test_publish_blob(send_mock, ack_mock, connect_mock, id, shard_by, avro_file
     if id:
         ack_mock.return_value = struct.pack(">Q", id)
 
-    c.publish_blob(file_contents, id=id, shard_by=shard_by)
+    sync = id is not None
+    c.publish_blob(file_contents, sync=sync, id=id, shard_by=shard_by)
     send_calls = send_mock.mock_calls
     assert(len(send_calls) == 1)
     send_call = send_calls[0]
@@ -61,7 +62,7 @@ def test_publish_blob(send_mock, ack_mock, connect_mock, id, shard_by, avro_file
 
     assert((len(payload_raw) - 4) == payload[0])  # Length of the binary blob
     assert(payload[1] == 1)  # Version number
-    assert(payload[2] == (1 if id else 0))  # Control
+    assert(payload[2] == (1 if sync else 0))  # Control
 
     if id:
         assert(payload[3] == id)


### PR DESCRIPTION
Per feedback, exposing id as the means by which users control async vs
sync publication was confusing. Users now control sync directly and,
optionally, the id of the payload.