### PR TITLE
Expose OCF Serialization to Users.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ src/
 .idea
 
 tests/data/
+.pytest_cache

--- a/pycernan/avro/dummy.py
+++ b/pycernan/avro/dummy.py
@@ -2,7 +2,7 @@ from pycernan.avro.client import Client
 
 
 class BaseDummyClient(Client):
-    def publish_blob(self, avro_blob):
+    def publish_blob(self, avro_blob, **kwargs):
         pass
 
 

--- a/pycernan/avro/exceptions.py
+++ b/pycernan/avro/exceptions.py
@@ -1,4 +1,5 @@
-import avro
+import avro.io
+import avro.schema
 
 SchemaParseException = avro.schema.SchemaParseException
 DatumTypeException = avro.io.AvroTypeException

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -1,0 +1,44 @@
+import json
+import sys
+
+from avro.io import DatumWriter
+from avro.datafile import DataFileWriter
+from io import BytesIO
+
+if sys.version_info >= (3, 0):
+    from avro.schema import Parse                   # pragma: no cover
+else:
+    from avro.schema import parse as Parse          # pragma: no cover
+
+
+def serialize(schema_map, batch, ephemeral_storage=False):
+    """
+        Serialize a batch of values, matching the given schema, as an
+        Avro object container file.
+
+        Args:
+            schema_map: dict - Avro schema defintion.
+            batch: list - List of Avro types.
+
+        Kwargs:
+            ephemeral_storage: bool - Flag to indicate whether the batch
+                                      should be stored long-term.
+
+        Returns:
+            bytes
+    """
+    parsed_schema = Parse(json.dumps(schema_map))
+    avro_buf = BytesIO()
+    with DataFileWriter(avro_buf, DatumWriter(), parsed_schema, 'deflate') as writer:
+        if ephemeral_storage:
+            # handle py2/py3 interface discrepancy
+            set_meta = getattr(writer, 'set_meta', None) or writer.SetMeta
+            set_meta('postmates.storage.ephemeral', '1')
+
+        for record in batch:
+            writer.append(record)
+
+        writer.flush()
+        encoded = avro_buf.getvalue()
+
+    return encoded

--- a/tests/unit/avro/test_client.py
+++ b/tests/unit/avro/test_client.py
@@ -1,13 +1,13 @@
-from io import BytesIO
 import mock
 import pytest
+
+from avro.io import DatumReader
+from avro.datafile import DataFileReader
+from io import BytesIO
 
 import settings
 from pycernan.avro import BaseDummyClient, DummyClient
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException, EmptyBatchException
-
-from avro.io import DatumReader
-from avro.datafile import DataFileReader
 
 
 USER_SCHEMA = {

--- a/tests/unit/avro/test_client.py
+++ b/tests/unit/avro/test_client.py
@@ -1,10 +1,6 @@
 import mock
 import pytest
 
-from avro.io import DatumReader
-from avro.datafile import DataFileReader
-from io import BytesIO
-
 import settings
 from pycernan.avro import BaseDummyClient, DummyClient
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException, EmptyBatchException
@@ -42,32 +38,27 @@ def test_publish_file(avro_file):
     c.publish_file(avro_file)
 
 
+@mock.patch('pycernan.avro.client.serialize', autospec=True)
 @pytest.mark.parametrize('ephemeral', [True, False])
-def test_publish(ephemeral):
+def test_publish(m_serialize, ephemeral):
+    expected_serialize_result = mock.MagicMock()
+    m_serialize.return_value = expected_serialize_result
+
     user = {
         'name': 'Foo Bar Matic',
         'favorite_number': 24,
         'favorite_color': 'Nonyabusiness',
     }
 
-    def inspect_publish_blob(avro_blob):
-        buf = BytesIO()
-        buf.write(avro_blob)
-        buf.seek(0)
-        with DataFileReader(buf, DatumReader()) as reader:
-            get_meta = getattr(reader, 'get_meta', None) or reader.GetMeta
-            value = get_meta('postmates.storage.ephemeral')
-            assert value is (b'1' if ephemeral else None)
-            records = [r for r in reader]
-            assert records == [user]
-
-    m_publish_blob = mock.MagicMock()
-    m_publish_blob.side_effect = inspect_publish_blob
-
     c = DummyClient()
-    c.publish_blob = m_publish_blob
-    c.publish(USER_SCHEMA, [user], ephemeral_storage=ephemeral)
-    assert m_publish_blob.call_count == 1
+    with mock.patch.object(c, 'publish_blob', autospec=True) as m_publish_blob:
+        c.publish(USER_SCHEMA, [user], ephemeral_storage=ephemeral, kwarg1='one', kwarg2='two')
+    assert m_serialize.call_args_list == [
+        mock.call(USER_SCHEMA, [user], ephemeral)
+    ]
+    assert m_publish_blob.call_args_list == [
+        mock.call(expected_serialize_result, kwarg1='one', kwarg2='two')
+    ]
 
 
 def test_publish_bad_schema():

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -1,0 +1,56 @@
+import pytest
+
+from avro.io import DatumReader
+from avro.datafile import DataFileReader
+from io import BytesIO
+
+from pycernan.avro.exceptions import SchemaParseException, DatumTypeException
+from pycernan.avro.serde import serialize
+
+
+USER_SCHEMA = {
+    "namespace": "example.avro",
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string"},
+        {"name": "favorite_number",  "type": ["int", "null"]},
+        {"name": "favorite_color", "type": ["string", "null"]}
+    ]
+}
+
+
+@pytest.mark.parametrize('ephemeral', [True, False])
+def test_serialize(ephemeral):
+    def inspect_publish_blob(avro_blob):
+        user = {
+            'name': 'Foo Bar Matic',
+            'favorite_number': 24,
+            'favorite_color': 'Nonyabusiness',
+        }
+
+        buf = BytesIO()
+        buf.write(avro_blob)
+        buf.seek(0)
+        with DataFileReader(buf, DatumReader()) as reader:
+            get_meta = getattr(reader, 'get_meta', None) or reader.GetMeta
+            value = get_meta('postmates.storage.ephemeral')
+            assert value is (b'1' if ephemeral else None)
+            records = [r for r in reader]
+            assert records == [user]
+
+        blob = serialize(USER_SCHEMA, [user], ephemeral_storage=ephemeral)
+        inspect_publish_blob(blob)
+
+
+def test_bad_schema():
+    schema = "Not a dict"
+    user = {}
+    with pytest.raises(SchemaParseException):
+        serialize(schema, [user])
+
+
+def test_bad_datum_empty():
+    user = {}
+    with pytest.raises(DatumTypeException):
+        serialize(USER_SCHEMA, [user])

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -22,25 +22,22 @@ USER_SCHEMA = {
 
 @pytest.mark.parametrize('ephemeral', [True, False])
 def test_serialize(ephemeral):
-    def inspect_publish_blob(avro_blob):
-        user = {
-            'name': 'Foo Bar Matic',
-            'favorite_number': 24,
-            'favorite_color': 'Nonyabusiness',
-        }
+    user = {
+        'name': 'Foo Bar Matic',
+        'favorite_number': 24,
+        'favorite_color': 'Nonyabusiness',
+    }
 
-        buf = BytesIO()
-        buf.write(avro_blob)
-        buf.seek(0)
-        with DataFileReader(buf, DatumReader()) as reader:
-            get_meta = getattr(reader, 'get_meta', None) or reader.GetMeta
-            value = get_meta('postmates.storage.ephemeral')
-            assert value is (b'1' if ephemeral else None)
-            records = [r for r in reader]
-            assert records == [user]
-
-        blob = serialize(USER_SCHEMA, [user], ephemeral_storage=ephemeral)
-        inspect_publish_blob(blob)
+    avro_blob = serialize(USER_SCHEMA, [user], ephemeral_storage=ephemeral)
+    buf = BytesIO()
+    buf.write(avro_blob)
+    buf.seek(0)
+    with DataFileReader(buf, DatumReader()) as reader:
+        get_meta = getattr(reader, 'get_meta', None) or reader.GetMeta
+        value = get_meta('postmates.storage.ephemeral')
+        assert value is (b'1' if ephemeral else None)
+        records = [r for r in reader]
+        assert records == [user]
 
 
 def test_bad_schema():


### PR DESCRIPTION
Some users want to leverage pycernan.avro's serializers
without publishing records via Cernan. For example, an ETL process which
wishes to own its retry policy.

This change adds `pycernan.avro.serde.serialize` to support such
use-cases.