### PR TITLE
Extend serialize to Accept Parsed Types.

### DIFF
--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -5,10 +5,11 @@ from avro.io import DatumWriter
 from avro.datafile import DataFileWriter
 from io import BytesIO
 
+
 if sys.version_info >= (3, 0):
-    from avro.schema import Parse                   # pragma: no cover
+    from avro.schema import Parse as parse      # pragma: no cover
 else:
-    from avro.schema import parse as Parse          # pragma: no cover
+    from avro.schema import parse               # pragma: no cover
 
 
 def serialize(schema_map, batch, ephemeral_storage=False):
@@ -17,7 +18,7 @@ def serialize(schema_map, batch, ephemeral_storage=False):
         Avro object container file.
 
         Args:
-            schema_map: dict or avro.schema.Parse - Avro schema defintion.
+            schema_map: dict or pycernan.avro.serde.parse - Avro schema defintion.
             batch: list - List of Avro types.
 
         Kwargs:
@@ -28,7 +29,7 @@ def serialize(schema_map, batch, ephemeral_storage=False):
             bytes
     """
     if isinstance(schema_map, dict):
-        parsed_schema = Parse(json.dumps(schema_map))
+        parsed_schema = parse(json.dumps(schema_map))
     else:
         parsed_schema = schema_map
 

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -17,7 +17,7 @@ def serialize(schema_map, batch, ephemeral_storage=False):
         Avro object container file.
 
         Args:
-            schema_map: dict - Avro schema defintion.
+            schema_map: dict or avro.schema.Parse - Avro schema defintion.
             batch: list - List of Avro types.
 
         Kwargs:
@@ -27,7 +27,11 @@ def serialize(schema_map, batch, ephemeral_storage=False):
         Returns:
             bytes
     """
-    parsed_schema = Parse(json.dumps(schema_map))
+    if isinstance(schema_map, dict):
+        parsed_schema = Parse(json.dumps(schema_map))
+    else:
+        parsed_schema = schema_map
+
     avro_buf = BytesIO()
     with DataFileWriter(avro_buf, DatumWriter(), parsed_schema, 'deflate') as writer:
         if ephemeral_storage:

--- a/tests/unit/avro/test_client.py
+++ b/tests/unit/avro/test_client.py
@@ -62,7 +62,7 @@ def test_publish(m_serialize, ephemeral):
 
 
 def test_publish_bad_schema():
-    schema = "Not a dict"
+    schema = {}
     user = {}
 
     c = DummyClient()

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from avro.io import DatumReader
@@ -5,7 +6,7 @@ from avro.datafile import DataFileReader
 from io import BytesIO
 
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException
-from pycernan.avro.serde import serialize
+from pycernan.avro.serde import Parse, serialize
 
 
 USER_SCHEMA = {
@@ -20,15 +21,16 @@ USER_SCHEMA = {
 }
 
 
+@pytest.mark.parametrize('schema', [USER_SCHEMA, Parse(json.dumps(USER_SCHEMA))])
 @pytest.mark.parametrize('ephemeral', [True, False])
-def test_serialize(ephemeral):
+def test_serialize(ephemeral, schema):
     user = {
         'name': 'Foo Bar Matic',
         'favorite_number': 24,
         'favorite_color': 'Nonyabusiness',
     }
 
-    avro_blob = serialize(USER_SCHEMA, [user], ephemeral_storage=ephemeral)
+    avro_blob = serialize(schema, [user], ephemeral_storage=ephemeral)
     buf = BytesIO()
     buf.write(avro_blob)
     buf.seek(0)
@@ -41,7 +43,7 @@ def test_serialize(ephemeral):
 
 
 def test_bad_schema():
-    schema = "Not a dict"
+    schema = {}
     user = {}
     with pytest.raises(SchemaParseException):
         serialize(schema, [user])

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -6,7 +6,7 @@ from avro.datafile import DataFileReader
 from io import BytesIO
 
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException
-from pycernan.avro.serde import Parse, serialize
+from pycernan.avro.serde import parse, serialize
 
 
 USER_SCHEMA = {
@@ -21,7 +21,7 @@ USER_SCHEMA = {
 }
 
 
-@pytest.mark.parametrize('schema', [USER_SCHEMA, Parse(json.dumps(USER_SCHEMA))])
+@pytest.mark.parametrize('schema', [USER_SCHEMA, parse(json.dumps(USER_SCHEMA))])
 @pytest.mark.parametrize('ephemeral', [True, False])
 def test_serialize(ephemeral, schema):
     user = {


### PR DESCRIPTION
Some users pre-parse their schemas into avro.schema.Parse types as an
optimization.