### PR TITLE
Add deserialization

### DIFF
--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -59,6 +59,7 @@ def deserialize(avro_bytes):
         buffer = BytesIO(avro_bytes)
     else:
         raise ValueError("avro_bytes must be a bytes object or file-like io object")
+
     with DataFileReader(buffer, DatumReader()) as reader:
         records = [r for r in reader]
     return records

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -1,9 +1,9 @@
 import json
 import sys
 
-from avro.io import DatumWriter
-from avro.datafile import DataFileWriter
-from io import BytesIO
+from avro.io import DatumWriter, DatumReader
+from avro.datafile import DataFileWriter, DataFileReader
+from io import BytesIO, IOBase
 
 
 if sys.version_info >= (3, 0):
@@ -47,3 +47,18 @@ def serialize(schema_map, batch, ephemeral_storage=False):
         encoded = avro_buf.getvalue()
 
     return encoded
+
+
+def deserialize(avro_bytes):
+    """
+        Deserialize encoded avro bytes.
+    """
+    if isinstance(avro_bytes, IOBase):
+        buffer = avro_bytes
+    elif isinstance(avro_bytes, bytes):
+        buffer = BytesIO(avro_bytes)
+    else:
+        raise ValueError("avro_bytes must be a bytes object or file-like io object")
+    with DataFileReader(buffer, DatumReader()) as reader:
+        records = [r for r in reader]
+    return records

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -55,6 +55,12 @@ def test_serialize_and_deserialize():
     assert len(test_records) == 1
     assert test_records[0] == user
 
+    test_buffer = BytesIO(avro_blob)
+    test_records2 = deserialize(test_buffer)
+    assert isinstance(test_records2, list)
+    assert len(test_records2) == 1
+    assert test_records2[0] == user
+
 
 def test_bad_schema():
     schema = {}
@@ -67,3 +73,8 @@ def test_bad_datum_empty():
     user = {}
     with pytest.raises(DatumTypeException):
         serialize(USER_SCHEMA, [user])
+
+
+def test_bad_arg_to_deserialize():
+    with pytest.raises(ValueError):
+        deserialize(47)

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -6,7 +6,7 @@ from avro.datafile import DataFileReader
 from io import BytesIO
 
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException
-from pycernan.avro.serde import parse, serialize
+from pycernan.avro.serde import parse, serialize, deserialize
 
 
 USER_SCHEMA = {
@@ -40,6 +40,20 @@ def test_serialize(ephemeral, schema):
         assert value is (b'1' if ephemeral else None)
         records = [r for r in reader]
         assert records == [user]
+
+
+def test_serialize_and_deserialize():
+    user = {
+        'name': 'Foo Bar Matic',
+        'favorite_number': 24,
+        'favorite_color': 'Nonyabusiness',
+    }
+
+    avro_blob = serialize(USER_SCHEMA, [user])
+    test_records = deserialize(avro_blob)
+    assert isinstance(test_records, list)
+    assert len(test_records) == 1
+    assert test_records[0] == user
 
 
 def test_bad_schema():


### PR DESCRIPTION
I need a deserialization method to add serde test for specific avro schemas and test events in postal-main. Rather than writing the deserialization code just for the test suite in postal-main, I thought it might be a good idea to centralize this in pycernan, along with the serialization code. That way, if anything ever changes about the way we do serialization or deserialization, we only have to change the code in one place.