### PR TITLE
Allow Users to Encode Custom Metadata in Avro

### DIFF
--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -12,10 +12,13 @@ else:
     from avro.schema import parse               # pragma: no cover
 
 
-def serialize(schema_map, batch, ephemeral_storage=False):
+def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
     """
         Serialize a batch of values, matching the given schema, as an
         Avro object container file.
+
+        Note - This function reserves the `postmates.` metadata keyspace for
+        for internal use.
 
         Args:
             schema_map: dict or pycernan.avro.serde.parse - Avro schema defintion.
@@ -24,6 +27,7 @@ def serialize(schema_map, batch, ephemeral_storage=False):
         Kwargs:
             ephemeral_storage: bool - Flag to indicate whether the batch
                                       should be stored long-term.
+            **metadata: dict - User defined metadata included in the header.
 
         Returns:
             bytes
@@ -36,9 +40,12 @@ def serialize(schema_map, batch, ephemeral_storage=False):
     avro_buf = BytesIO()
     with DataFileWriter(avro_buf, DatumWriter(), parsed_schema, 'deflate') as writer:
         if ephemeral_storage:
+            metadata['postmates.storage.ephemeral'] = '1'
+
+        for k, v in metadata.items():
             # handle py2/py3 interface discrepancy
             set_meta = getattr(writer, 'set_meta', None) or writer.SetMeta
-            set_meta('postmates.storage.ephemeral', '1')
+            set_meta(k, str(v))
 
         for record in batch:
             writer.append(record)

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -72,6 +72,6 @@ def deserialize(avro_bytes, decode_schema=False):
         records = [r for r in reader]
 
     if decode_schema:
-        metadata['avro.schema'] = json.loads(metadata['avro.schema'])
+        metadata['avro.schema'] = json.loads(metadata['avro.schema'].decode('utf-8'))
 
     return metadata, records


### PR DESCRIPTION
Users of avro.serde.serialize may now specify additional metadata
key/value pairs to include within the header of the resulting payload.