### PR TITLE
Add postmates/avro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ sdist:
 
 .PHONY: install
 install: all
-	pip install . --process-dependency-links
+	pip install -r ./requirements.txt --process-dependency-links
 
 .PHONY: clean-all
 clean-all: clean

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ sdist:
 
 .PHONY: install
 install: all
-	python setup.py install
+	pip install . --process-dependency-links
 
 .PHONY: clean-all
 clean-all: clean

--- a/pycernan/avro/README.md
+++ b/pycernan/avro/README.md
@@ -6,6 +6,15 @@
 * Publish Avro from: dicts, files, and raw blobs.
 * Synchronous and asynchronous publication.
 
+## Note on Avro Library
+* Pycernan installs the [Postmates fork](https://github.com/postmates/avro) of the Apache Avro Library
+* The Python2 version of the Postmates fork currently maps several native Python types to Avro logical types:
+  * Python `datetime.datetime` objects are mapped to Avro types `{'logicalType': 'timestamp-millis', 'type': 'long'}` or `{'logicalType': 'timestamp-micros', 'type': 'long'}`, depending on the Avro schema.
+  * Python `datetime.time` objects are mapped to Avro types `{'logicalType': 'time-millis', 'type': 'int'}` or `{'logicalType': 'time-micros', 'type': 'long'}`, depending on the Avro schema.
+  * Python `datetime.date` objects are mapped to `{'logicalType': 'date', 'type': 'int'}`.
+  * Python `decimal.Decimal` objects are mapped to `{'logicalType': 'decimal', 'type': 'string'}`.
+* The Python3 version of the Postmates fork is currently identical to the upstream Apache repo.
+
 ## Usage
 
 ```python
@@ -78,4 +87,3 @@ Avro blobs are pregenerated and published at random.  Data used is the same data
 |           Scenario              |         Throughput         |     Latency Min/Mean/Max (microseconds)   |    Limiting Factor     |
 |:-------------------------------:|:--------------------------:|:-----------------------------------------:|:-----------------------|
 |  [Pregenerated](#pregenerated)  |   ~1.4k blobs / second     |          107 / 462 / 7.6k                 |          CPU           |
-

--- a/pycernan/avro/README.md
+++ b/pycernan/avro/README.md
@@ -6,15 +6,6 @@
 * Publish Avro from: dicts, files, and raw blobs.
 * Synchronous and asynchronous publication.
 
-## Note on Avro Library
-* Pycernan installs the [Postmates fork](https://github.com/postmates/avro) of the Apache Avro Library
-* The Python2 version of the Postmates fork currently maps several native Python types to Avro logical types:
-  * Python `datetime.datetime` objects are mapped to Avro types `{'logicalType': 'timestamp-millis', 'type': 'long'}` or `{'logicalType': 'timestamp-micros', 'type': 'long'}`, depending on the Avro schema.
-  * Python `datetime.time` objects are mapped to Avro types `{'logicalType': 'time-millis', 'type': 'int'}` or `{'logicalType': 'time-micros', 'type': 'long'}`, depending on the Avro schema.
-  * Python `datetime.date` objects are mapped to `{'logicalType': 'date', 'type': 'int'}`.
-  * Python `decimal.Decimal` objects are mapped to `{'logicalType': 'decimal', 'type': 'string'}`.
-* The Python3 version of the Postmates fork is currently identical to the upstream Apache repo.
-
 ## Usage
 
 ```python
@@ -44,6 +35,15 @@ client.publish(schema, records)
 # Async publish records.
 client.publish(schema, records, sync=False)
 ```
+
+## Note on Avro Library
+* Pycernan installs the [Postmates fork](https://github.com/postmates/avro) of the Apache Avro Library
+* The Python2 version of the Postmates fork currently maps several native Python types to Avro logical types:
+  * Python `datetime.datetime` objects are mapped to Avro types `{'logicalType': 'timestamp-millis', 'type': 'long'}` or `{'logicalType': 'timestamp-micros', 'type': 'long'}`, depending on the Avro schema.
+  * Python `datetime.time` objects are mapped to Avro types `{'logicalType': 'time-millis', 'type': 'int'}` or `{'logicalType': 'time-micros', 'type': 'long'}`, depending on the Avro schema.
+  * Python `datetime.date` objects are mapped to `{'logicalType': 'date', 'type': 'int'}`.
+  * Python `decimal.Decimal` objects are mapped to `{'logicalType': 'decimal', 'type': 'string'}`.
+* The Python3 version of the Postmates fork is currently identical to the upstream Apache repo.
 
 ## Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 --index-url https://pypi.python.org/simple/
-git+git://github.com/postmates/avro.git#subdirectory=lang/py
--e .
+-e . --process-dependency-links

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://pypi.python.org/simple/
--e . 
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://pypi.python.org/simple/
--e . --process-dependency-links
+-e . 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 --index-url https://pypi.python.org/simple/
+git+git://github.com/postmates/avro.git#subdirectory=lang/py
 -e .

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,11 @@ setup(
     ],
     extras_require={
         ":python_version<'3.0'": ["avro==1.8.2+postmates.1"],
-        ":python_version>='3.0'": ["avro-python3"],
+        ":python_version>='3.0'": ["avro-python3==1.8.2+postmates.1"],
     },
     dependency_links=[
         "https://github.com/postmates/avro/tarball/version-bump#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
+        "https://github.com/postmates/avro/tarball/version-bump#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
     ],
     include_package_data=True,
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         ":python_version>='3.0'": ["avro-python3"],
     },
     dependency_links=[
+        "git+git://github.com/postmates/avro.git#subdirectory=lang/py"
     ],
     include_package_data=True,
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         ":python_version>='3.0'": ["avro-python3==1.8.2+postmates.1"],
     },
     dependency_links=[
-        "https://github.com/postmates/avro/tarball/version-bump#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
-        "https://github.com/postmates/avro/tarball/version-bump#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
+        "git+https://github.com/postmates/avro.git@version-bump#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
+        "git+https://github.com/postmates/avro.git@version-bump#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
     ],
     include_package_data=True,
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     install_requires=[
     ],
     extras_require={
-        ":python_version<'3.0'": ["avro"],
+        ":python_version<'3.0'": ["avro==1.8.2+postmates.1"],
         ":python_version>='3.0'": ["avro-python3"],
     },
     dependency_links=[
-        "git+git://github.com/postmates/avro.git#subdirectory=lang/py"
+        "https://github.com/postmates/avro/tarball/version-bump#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
     ],
     include_package_data=True,
     scripts=[],

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         ":python_version>='3.0'": ["avro-python3==1.8.2+postmates.1"],
     },
     dependency_links=[
-        "git+https://github.com/postmates/avro.git@version-bump#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
-        "git+https://github.com/postmates/avro.git@version-bump#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
+        "git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
+        "git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
     ],
     include_package_data=True,
     scripts=[],

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py27,py3
 
 [testenv]
 whitelist_externals = make
+install_command = pip install {opts} {packages} --process-dependency-links
 deps = -rrequirements-test.txt
 usedevelop = True
 setenv = PYTHONDONTWRITEBYTECODE = 1


### PR DESCRIPTION
Pycernan should use the Postmates fork of the avro library, which has been given a local version tag.