### PR TITLE
Allow Users to Skip Decoding Avro Values

### DIFF
--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -56,7 +56,7 @@ def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
     return encoded
 
 
-def deserialize(avro_bytes, decode_schema=False, decode_values=True):
+def deserialize(avro_bytes, decode_schema=False):
     """
         Deserialize encoded avro bytes.
 
@@ -65,16 +65,14 @@ def deserialize(avro_bytes, decode_schema=False, decode_values=True):
 
         Kwargs:
             decode_schema: Bool - Load metadata['avro.schema'] as JSON?.  Default = False.
-            decode_values: Bool - Decode & return values immediately?  Default = True.
 
         Returns:
             (metadata, values) where:
                 metadata: dict - Avro metadata as raw bytes.  When decode_schema is True,
                     the key 'avro.schema' value will be loaded as JSON.
 
-                values: List | generator - List of values corresponding to schema contained in
-                    metadata.  When decode_values is False, an Avro value generator is returned which
-                    users can leverage to iterate over values awaiting decode.
+                values: generator - Generator for values corresponding to the schema contained
+                    in metadata.
 
     """
     def _avro_generator(datafile_reader):
@@ -92,8 +90,6 @@ def deserialize(avro_bytes, decode_schema=False, decode_values=True):
     reader = DataFileReader(buffer, DatumReader())
     values = _avro_generator(reader)
     metadata = reader.meta
-    if decode_values:
-        values = [value for value in values]
 
     if decode_schema:
         metadata['avro.schema'] = json.loads(metadata['avro.schema'].decode('utf-8'))

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -64,9 +64,9 @@ def test_serialize_and_deserialize():
     }
 
     avro_blob = serialize(USER_SCHEMA, [user])
-    (test_meta, test_records) = deserialize(avro_blob, decode_schema=True)
+    (test_meta, test_generator) = deserialize(avro_blob, decode_schema=True)
     assert isinstance(test_meta, dict)
-    assert isinstance(test_records, list)
+    assert isinstance(test_generator, types.GeneratorType)
     assert isinstance(test_meta['avro.schema'], dict)
 
     test_schema = test_meta['avro.schema']
@@ -74,19 +74,22 @@ def test_serialize_and_deserialize():
     assert test_schema['namespace'] == USER_SCHEMA['namespace']
     assert test_schema['fields'] == USER_SCHEMA['fields']
 
+    test_records = [value for value in test_generator]
     assert len(test_records) == 1
     assert test_records[0] == user
 
     test_buffer = BytesIO(avro_blob)
-    test_meta, test_records2 = deserialize(test_buffer)
+    test_meta, test_generator = deserialize(test_buffer)
     assert isinstance(test_meta['avro.schema'], bytes)
-    assert isinstance(test_records2, list)
-    assert len(test_records2) == 1
-    assert test_records2[0] == user
+    assert isinstance(test_generator, types.GeneratorType)
+
+    test_records = [value for value in test_generator]
+    assert len(test_records) == 1
+    assert test_records[0] == user
 
     # Ensure deserialize skips decoding values when instructed.
     test_buffer = BytesIO(avro_blob)
-    test_meta, test_generator = deserialize(test_buffer, decode_values=False)
+    test_meta, test_generator = deserialize(test_buffer)
     assert isinstance(test_generator, types.GeneratorType)
     assert [value for value in test_generator] == [user]
 

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -87,12 +87,6 @@ def test_serialize_and_deserialize():
     assert len(test_records) == 1
     assert test_records[0] == user
 
-    # Ensure deserialize skips decoding values when instructed.
-    test_buffer = BytesIO(avro_blob)
-    test_meta, test_generator = deserialize(test_buffer)
-    assert isinstance(test_generator, types.GeneratorType)
-    assert [value for value in test_generator] == [user]
-
 
 def test_serialize_with_metadata():
     metadata = {

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -83,6 +83,14 @@ def test_serialize_and_deserialize():
     assert len(test_records2) == 1
     assert test_records2[0] == user
 
+    # Ensure deserialize skips decoding values when instructed.
+    test_buffer = BytesIO(avro_blob)
+    test_meta, test_datafile = deserialize(test_buffer, decode_values=False)
+    assert isinstance(test_datafile, DataFileReader)
+    with test_datafile:
+        test_datafile_contents = [r for r in test_datafile]
+    assert test_datafile_contents == [user]
+
 
 def test_serialize_with_metadata():
     metadata = {

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import types
 
 from avro.io import DatumReader
 from avro.datafile import DataFileReader
@@ -85,11 +86,9 @@ def test_serialize_and_deserialize():
 
     # Ensure deserialize skips decoding values when instructed.
     test_buffer = BytesIO(avro_blob)
-    test_meta, test_datafile = deserialize(test_buffer, decode_values=False)
-    assert isinstance(test_datafile, DataFileReader)
-    with test_datafile:
-        test_datafile_contents = [r for r in test_datafile]
-    assert test_datafile_contents == [user]
+    test_meta, test_generator = deserialize(test_buffer, decode_values=False)
+    assert isinstance(test_generator, types.GeneratorType)
+    assert [value for value in test_generator] == [user]
 
 
 def test_serialize_with_metadata():


### PR DESCRIPTION
Users can now optionally skip decoding Avro values in
pycernan.avro.serde.deserialize by specifying the kwarg
decode_values=False.  When False, only the Avro metadata will be parsed
and a DataFileReader returned to the user for later decoding.

This feature is useful in cases where a consumer only wishes to process
certain Avro types, time is not wasted decoding values they are
uninterested in.