### PR TITLE
Remove --process-dependency-links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 --index-url https://pypi.python.org/simple/
+
+git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py ; python_version < '3.0'
+git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py3 ; python_version >= '3.0'
+
 -e .

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+import sys
+
 from setuptools import setup, find_packages
+
+if sys.version_info >= (3, 0):
+    install_requires = ['avro-python3>=1.8.2']
+else:
+    install_requires = ['avro>=1.8.2']
 
 setup(
     name="pycernan",
@@ -16,16 +23,7 @@ setup(
         'pytest-timeout',
         'mock>=1.0.1',
     ],
-    install_requires=[
-    ],
-    extras_require={
-        ":python_version<'3.0'": ["avro==1.8.2+postmates.1"],
-        ":python_version>='3.0'": ["avro-python3==1.8.2+postmates.1"],
-    },
-    dependency_links=[
-        "git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py&egg=avro-1.8.2+postmates.1",
-        "git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py3&egg=avro-python3-1.8.2+postmates.1",
-    ],
+    install_requires=install_requires,
     include_package_data=True,
     scripts=[],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist = py27,py3
 
 [testenv]
 whitelist_externals = make
-install_command = pip install {opts} {packages} --process-dependency-links
 deps = -rrequirements-test.txt
 usedevelop = True
 setenv = PYTHONDONTWRITEBYTECODE = 1


### PR DESCRIPTION
This feature is deprecated.  Instead we make use of environment markers
in requirements.txt.