### PR TITLE
Allow user to specify different reader_schema when deserializing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ sdist:
 
 .PHONY: install
 install: all
-	pip install -r ./requirements.txt --process-dependency-links
+	pip install -r ./requirements.txt
 
 .PHONY: clean-all
 clean-all: clean


### PR DESCRIPTION
When deserializing, a user should be able to specify a different reader schema as the kwarg `reader_schema`.

- If `reader_schema` is `None` or omitted, `deserialize` works as before, using the writer's schema.
- If `reader_schema` is incompatible with the writer's schema, a `SchemaResolutionException` is thrown by the avro library.
- If `reader_schema` is compatible, the data blob will be decoded with that schema, using the default values specified in the reader schema for any fields not present in the data blob.

Note: `metadata['avro.schema']` returned by `deserialize` will contain the original writer schema.

*One more thing: I removed --process-dependency-links from the makefile, since we aren't using dependency links in setup.py*
