### PR TITLE
Add TCPConnectionPool to avro.Client.

### DIFF
--- a/pycernan/avro/client.py
+++ b/pycernan/avro/client.py
@@ -28,7 +28,6 @@ class TCPConnectionPool(object):
 
         self.host = host
         self.port = port
-        self.size = 0
         self.maxsize = maxsize
 
         self.connect_timeout = connect_timeout

--- a/pycernan/avro/client.py
+++ b/pycernan/avro/client.py
@@ -21,6 +21,11 @@ class TCPConnectionPool(object):
     Fork friendly TCP connection pool.
 
     Adapted from: https://github.com/gevent/gevent/blob/master/examples/psycopg2_pool.py
+
+    All exceptions (application, operation (timeouts, etc)) are the responsibility of the user to
+    handle responsibly.  One day, with sufficient time and motivation, this class could be made
+    more intelligent to handle connection related exceptions distinct from application layer
+    concerns.
     """
     def __init__(self, host, port, maxsize, connect_timeout, read_timeout):
         if maxsize <= 0:

--- a/pycernan/avro/client.py
+++ b/pycernan/avro/client.py
@@ -109,7 +109,7 @@ class Client(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, host=None, port=None, maxsize=10, connect_timeout=50, publish_timeout=10):
+    def __init__(self, host=None, port=None, connect_timeout=50, publish_timeout=10, maxsize=10):
         host = host or pycernan.avro.config.host()
         port = port or pycernan.avro.config.port()
 
@@ -119,9 +119,9 @@ class Client(object):
         self.pool = TCPConnectionPool(
             host,
             port,
-            maxsize,
-            connect_timeout,
-            publish_timeout)
+            maxsize=maxsize,
+            connect_timeout=connect_timeout,
+            read_timeout=publish_timeout)
 
     def close(self):
         """

--- a/pycernan/avro/exceptions.py
+++ b/pycernan/avro/exceptions.py
@@ -15,3 +15,7 @@ class InvalidAckException(Exception):
 
 class ConnectionResetException(Exception):
     pass
+
+
+class EmptyPoolException(Exception):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py ; python_version < '3.0'
 git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py3 ; python_version >= '3.0'
 
--e .
+.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from pycernan import __version__
 if sys.version_info >= (3, 0):
     install_requires = ['avro-python3>=1.8.2']
 else:
-    install_requires = ['avro>=1.8.2']
+    install_requires = ['future', 'avro>=1.8.2']
 
 setup(
     name="pycernan",

--- a/tests/unit/avro/test_client.py
+++ b/tests/unit/avro/test_client.py
@@ -2,7 +2,11 @@ import mock
 import pytest
 
 import settings
+
+from queue import Queue
+
 from pycernan.avro import BaseDummyClient, DummyClient
+from pycernan.avro.client import TCPConnectionPool, DefunctConnection, EmptyPoolException
 from pycernan.avro.exceptions import SchemaParseException, DatumTypeException, EmptyBatchException
 
 
@@ -19,10 +23,15 @@ USER_SCHEMA = {
 
 
 class FakeSocket(object):
-    def __init__(self):
+    def __init__(self, num_failures=0):
+        self.num_failures = num_failures
         self.call_args_list = []
 
     def settimeout(self, *args, **kwargs):
+        if self.num_failures > 0:
+            self.num_failures -= 1
+            raise Exception("Oops")
+
         self.call_args_list.append(('settimeout', mock.call(*args, **kwargs)))
 
     def close(self):
@@ -30,6 +39,112 @@ class FakeSocket(object):
 
     def _reset_mock(self):
         self.call_args_list = []
+
+
+class ForcedException(Exception):
+    pass
+
+
+class TestTCPConnectionPool():
+
+    @mock.patch.object(TCPConnectionPool, 'create_connection', return_value=None, autospec=True)
+    def test_pool_creation_is_lazy_relative_to_first_use(self, connection_mock):
+        pool = TCPConnectionPool('foobar', 80, 10, 3, 1)
+        assert pool.pool is None
+
+        with pool.connection():
+            assert pool.pool is not None
+
+    @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
+    def test_connection(self, connect_mock):
+        mock_sock = FakeSocket()
+        host, port = ('foobar', 9000)
+        connect_timeout, recv_timeout = (1, 1)
+        connect_mock.return_value = mock_sock
+        pool = TCPConnectionPool(host, port, 1, connect_timeout, recv_timeout)
+
+        with pool.connection() as sock:
+            assert sock == mock_sock
+            assert mock_sock.call_args_list == [('settimeout', mock.call(recv_timeout))]
+            assert connect_mock.call_args_list == [mock.call((host, port), timeout=connect_timeout)]
+
+        # After using a connection, it should be checked-in/cached for others to use
+        connect_mock.return_value = FakeSocket()
+        assert not pool.pool.empty()
+        with pool.connection() as sock:
+            assert sock == mock_sock
+
+            # When we are at capacity, then callers will block
+            # waiting for a connection to be returned.
+            with pytest.raises(EmptyPoolException):
+                with pool.connection(_block=False):
+                    assert False  # Should not be reached
+
+    @mock.patch.object(TCPConnectionPool, 'create_connection', side_effect=ForcedException("Oops"), autospec=True)
+    def test_create_connection_reraises(self, create_connection_mock):
+        pool = TCPConnectionPool('foobar', 80, 10, 1, 1)
+        with pytest.raises(ForcedException):
+            with pool.connection():
+                assert False  # Should not be reached.
+
+            # No connections become cached.
+            assert pool.pool.qsize() == 0
+            assert pool.size == 0
+
+    @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
+    def test_exceptions_result_in_defunct_connections(self, connect_mock):
+        pool = TCPConnectionPool('foobar', 80, 10, 1, 1)
+        mock_sock = FakeSocket()
+        connect_mock.return_value = mock_sock
+
+        with pytest.raises(ForcedException):
+            with pool.connection():
+                raise ForcedException()
+
+        assert pool.pool.qsize() == 1
+        assert pool.pool.get_nowait() == DefunctConnection
+
+    @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
+    def test_defunct_connections_are_regenerated(self, connect_mock):
+        pool = TCPConnectionPool('foobar', 80, 10, 1, 1)
+        mock_sock = FakeSocket()
+        connect_mock.return_value = mock_sock
+
+        pool.pool = Queue()
+        pool.pool.put(DefunctConnection)
+        with pool.connection() as conn:
+            assert conn is mock_sock
+
+    @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
+    def test_regenerating_connections_tolerates_exceptions(self, connect_mock):
+        num_failures = 20
+        pool = TCPConnectionPool('foobar', 80, 10, 1, 1)
+        mock_sock = FakeSocket(num_failures=num_failures)
+        connect_mock.return_value = mock_sock
+
+        # Simulate a prior failure
+        pool.pool = Queue()
+        pool.size = 1
+        pool.pool.put(DefunctConnection)
+
+        # Try a number of failed operations.
+        # Each time the defunct connection should be returned to the queue
+        # for subsequent calls to reattempt.
+        for i in range(num_failures):
+            with pytest.raises(Exception):
+                with pool.connection():
+                    assert False  # Should not be reached
+
+            assert pool.pool.qsize() == pool.size == 1
+            assert pool.pool.get_nowait() is DefunctConnection
+            pool.pool.put(DefunctConnection)
+
+        # Failures are exhausted, we should be able to now
+        # regenerate a valid context.
+        with pool.connection():
+            pass
+        assert pool.pool.qsize() == 1
+        assert pool.pool.get_nowait() is mock_sock
 
 
 @pytest.mark.parametrize("avro_file", settings.test_data)
@@ -86,17 +201,20 @@ def test_publish_empty_batch():
 
 @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
 def test_creating_a_client_connects_a_socket(m_connect):
+    connect_timeout = 1
+    publish_timeout = 50
     expected_sock = FakeSocket()
     m_connect.return_value = expected_sock
 
     client = BaseDummyClient(
         host='some fake host',
         port=31337,
-        connect_timeout=666,
-        publish_timeout=999)
-    assert client.sock == expected_sock
-    assert expected_sock.call_args_list == [('settimeout', mock.call(999))]
-    assert m_connect.call_args_list == [mock.call(('some fake host', 31337), timeout=666)]
+        connect_timeout=connect_timeout,
+        publish_timeout=publish_timeout)
+
+    with client.pool.connection():
+        assert expected_sock.call_args_list == [('settimeout', mock.call(publish_timeout))]
+        assert m_connect.call_args_list == [mock.call(('some fake host', 31337), timeout=connect_timeout)]
 
 
 @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
@@ -110,12 +228,18 @@ def test_closing_the_client_closes_the_socket_and_clears_it(m_connect):
         connect_timeout=666,
         publish_timeout=999)
 
-    assert client.sock is not None
+    with client.pool.connection():
+        pass  # Generates a connection
+
+    assert client.pool is not None
+    assert client.pool.pool.qsize() == 1
+
     expected_sock._reset_mock()
     client.close()
 
     assert expected_sock.call_args_list == [('close', mock.call())]
-    assert client.sock is None
+    assert client.pool is not None
+    assert client.pool.pool.qsize() == 0
 
 
 @mock.patch('pycernan.avro.client.socket.create_connection', autospec=True)
@@ -128,7 +252,4 @@ def test_closing_the_client_with_no_socket_does_not_crash(m_connect):
         port=31337,
         connect_timeout=666,
         publish_timeout=999)
-    client.close()
-
-    assert client.sock is None
     client.close()


### PR DESCRIPTION
Existing socket abstractions in pycernan.avro do not provide any level
of isolation for callers.  In practice this translates to a single
timeout, for example, resulting in subsequent publishers receiving acks
out of order when a Client is reused without first being reconstructed.

Rather than forcing users to think about this and to make it easier for
users to take advantage of connection level threading within Cernan, we
introduce a connection pool to avro.Client which has the following properties:

* Fork-safe as long as the Client isn't used prior to forking.

* Established connections are preferred over establishing new
connections.

* Exceptions (on connect or during publication) are re-raised back to
the caller.

* Whenever a pool connection experiences an Exception, either operational
or specific to Cernan's wire protocol, the connection will be
re-established in a lazy fashion.  That is, on the next operation
assigned to that socket.