### PR TITLE
Port pycernan.avro to fastavro.

### DIFF
--- a/pycernan/avro/exceptions.py
+++ b/pycernan/avro/exceptions.py
@@ -1,8 +1,9 @@
-import avro.io
-import avro.schema
+import fastavro
 
-SchemaParseException = avro.schema.SchemaParseException
-DatumTypeException = avro.io.AvroTypeException
+SchemaParseException = (fastavro.schema.SchemaParseException, KeyError)
+SchemaResolutionException = fastavro.read.SchemaResolutionError
+UnknownTypeException = fastavro.schema.UnknownType
+DatumTypeException = ValueError
 
 
 class EmptyBatchException(Exception):

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -2,15 +2,8 @@ import json
 import sys
 import types
 
-from avro.io import DatumWriter, DatumReader
-from avro.datafile import DataFileWriter, DataFileReader
+from fastavro import reader, writer, parse_schema
 from io import BytesIO, IOBase
-
-
-if sys.version_info >= (3, 0):
-    from avro.schema import Parse as parse      # pragma: no cover
-else:
-    from avro.schema import parse               # pragma: no cover
 
 
 def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
@@ -34,31 +27,27 @@ def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
             bytes
     """
     if isinstance(schema_map, dict):
-        parsed_schema = parse(json.dumps(schema_map))
+        parsed_schema = parse_schema(schema_map)
     else:
         parsed_schema = schema_map
 
     avro_buf = BytesIO()
-    with DataFileWriter(avro_buf, DatumWriter(), parsed_schema, 'deflate') as writer:
-        if ephemeral_storage:
-            metadata['postmates.storage.ephemeral'] = '1'
 
-        for k, v in metadata.items():
-            # handle py2/py3 interface discrepancy
-            set_meta = getattr(writer, 'set_meta', None) or writer.SetMeta
-            set_meta(k, str(v))
+    if ephemeral_storage:
+        metadata['postmates.storage.ephemeral'] = '1'
 
-        for record_or_generator in batch:
-            if isinstance(record_or_generator, types.GeneratorType):
-                for record in record_or_generator:
-                    writer.append(record)
-            else:
-                writer.append(record_or_generator)
+    for k, v in metadata.items():
+        if not isinstance(v, str):
+            metadata[k] = str(v)
 
-        writer.flush()
-        encoded = avro_buf.getvalue()
+    for record_or_generator in batch:
+        write_data = [record_or_generator]
+        if isinstance(record_or_generator, types.GeneratorType):
+            # Fast avro doesn't handle iterators within iterators gracefully..
+            write_data = record_or_generator
+        writer(avro_buf, parsed_schema, write_data, codec='deflate', metadata=metadata)
 
-    return encoded
+    return avro_buf.getvalue()
 
 
 def deserialize(avro_bytes, decode_schema=False, reader_schema=None):
@@ -83,9 +72,8 @@ def deserialize(avro_bytes, decode_schema=False, reader_schema=None):
 
     """
     def _avro_generator(datafile_reader):
-        with datafile_reader:
-            for value in datafile_reader:
-                yield value
+        for value in datafile_reader:
+            yield value
 
     if isinstance(avro_bytes, IOBase):
         buffer = avro_bytes
@@ -94,21 +82,14 @@ def deserialize(avro_bytes, decode_schema=False, reader_schema=None):
     else:
         raise ValueError("avro_bytes must be a bytes object or file-like io object")
 
-    if reader_schema:
-        parsed_reader_schema = parse(json.dumps(reader_schema))
-    else:
-        parsed_reader_schema = None
-
-    # NOTE: "reader_schema" in py3, "readers_schema" in py2! :facepalm:
-    if sys.version_info >= (3, 0):
-        reader = DataFileReader(buffer, DatumReader(reader_schema=parsed_reader_schema))
-    else:
-        reader = DataFileReader(buffer, DatumReader(readers_schema=parsed_reader_schema))
-
-    values = _avro_generator(reader)
-    metadata = reader.meta
+    read = reader(buffer, reader_schema=reader_schema)
+    values = _avro_generator(read)
+    metadata = read.metadata
 
     if decode_schema:
-        metadata['avro.schema'] = json.loads(metadata['avro.schema'].decode('utf-8'))
+        schema = metadata['avro.schema']
+        if sys.version_info < (3, 0):
+            schema = schema.decode('utf-8')
+        metadata['avro.schema'] = json.loads(schema)
 
     return metadata, values

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -26,11 +26,7 @@ def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
         Returns:
             bytes
     """
-    if isinstance(schema_map, dict):
-        parsed_schema = parse_schema(schema_map)
-    else:
-        parsed_schema = schema_map
-
+    parsed_schema = parse_schema(schema_map)
     avro_buf = BytesIO()
 
     if ephemeral_storage:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,6 @@ pytest
 pytest-cov
 pytest-timeout
 mock
+pytz
 
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 --index-url https://pypi.python.org/simple/
 
-git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py ; python_version < '3.0'
-git+https://github.com/postmates/avro.git@1.8.2+postmates.1#subdirectory=lang/py3 ; python_version >= '3.0'
-
 .

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,8 @@
-import sys
-
 from setuptools import setup, find_packages
 
 from pycernan import __version__
 
-if sys.version_info >= (3, 0):
-    install_requires = ['avro-python3>=1.8.2']
-else:
-    install_requires = ['future', 'avro>=1.8.2']
+install_requires = ['fastavro', 'future']
 
 setup(
     name="pycernan",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'pytest-cov',
         'pytest-timeout',
         'mock>=1.0.1',
+        'pytz',
     ],
     install_requires=install_requires,
     include_package_data=True,

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import pytest
 import types
 
@@ -155,6 +156,18 @@ TEST_SCHEMA_LOGICAL_TYPES = {
             "default": None,
             "doc": "customer uuid",
         },
+        {
+            "name": "decimal_bytes",
+            "type": ["null", {"type": "bytes", "logicalType": "decimal", "precision": 15, "scale": 3}],
+            "default": None,
+            "doc": "some decimal",
+        },
+        {
+            "name": "decimal_fixed",
+            "type": ["null", {"name": "n", "type": "fixed", "size": 8, "logicalType": "decimal", "precision": 15, "scale": 3}],
+            "default": None,
+            "doc": "some decimal",
+        },
     ]
 }
 
@@ -165,7 +178,9 @@ def test_logical_types():
 
     event = {
         'ts': datetime.utcnow().replace(tzinfo=timezone('UTC')),
-        'customer_uuid': 'some_random_uuid'
+        'customer_uuid': 'some_random_uuid',
+        'decimal_bytes': Decimal("-2.90"),
+        'decimal_fixed': Decimal("3.68"),
     }
 
     avro_blob = serialize(TEST_SCHEMA_LOGICAL_TYPES, [event])

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -138,6 +138,45 @@ def test_serialize_and_deserialize():
     assert test_records[0] == user
 
 
+TEST_SCHEMA_LOGICAL_TYPES = {
+    "type": "record",
+    "namespace": "com.postmates.test",
+    "name": "test_event_logical_types",
+    "fields": [
+        {
+            "name": "ts",
+            "type": ["null", {"type": "long", "logicalType": "timestamp-micros"}],
+            "default": None,
+            "doc": "some timestamp",
+        },
+        {
+            "name": "customer_uuid",
+            "type": ["null", "string"],
+            "default": None,
+            "doc": "customer uuid",
+        },
+    ]
+}
+
+
+def test_logical_types():
+    from datetime import datetime
+    from pytz import timezone
+
+    event = {
+        'ts': datetime.utcnow().replace(tzinfo=timezone('UTC')),
+        'customer_uuid': 'some_random_uuid'
+    }
+
+    avro_blob = serialize(TEST_SCHEMA_LOGICAL_TYPES, [event])
+
+    (test_meta, test_generator) = deserialize(avro_blob, decode_schema=True)
+    assert isinstance(test_generator, types.GeneratorType)
+    test_records = [value for value in test_generator]
+    assert len(test_records) == 1
+    assert test_records[0] == event
+
+
 def test_serialize_and_deserialize_with_reader_schema():
     book = {
         'title': 'Nineteen Eighty-Four',


### PR DESCRIPTION
In local benchmarks, fastavro performs 10x better than the standard
Python native Avro library, reducing overall CPU usage.  The following
semantic changes are observed as part of this change:

* Returned header values (metadata, etc) are now string_types instead of
binary strings.

* A new exception SchemaResolutionException has been added, fixing an
abstraction leak.

* Null default values must now be specified as `None` instead of `null`.