### PR TITLE
Avro source v2 client

### DIFF
--- a/pycernan/avro/base_client.py
+++ b/pycernan/avro/base_client.py
@@ -1,0 +1,41 @@
+import random
+import struct
+
+from pycernan.avro.client import Client
+from pycernan.avro.exceptions import ConnectionResetException, InvalidAckException
+
+
+def _hash_u64(value):
+    return hash(value) % 2 ** 64
+
+
+def _rand_u64():
+    return random.randrange(2 ** 64)
+
+
+class BaseClient(Client):
+    def _send_exact(self, sock, payload):
+        sock.sendall(payload)
+
+    def _recv_exact(self, sock, n_bytes):
+        buf = bytearray(b'')
+        while len(buf) < n_bytes:
+            recvd = sock.recv(n_bytes - len(buf))
+            if len(recvd) == 0:
+                raise ConnectionResetException()
+
+            buf.extend(recvd)
+
+        return bytes(buf)
+
+    def _send(self, payload_id, sync, payload):
+        with self.pool.connection() as sock:
+            self._send_exact(sock, payload)
+            if sync:
+                self._wait_for_ack(sock, payload_id)
+
+    def _wait_for_ack(self, sock, payload_id):
+        id_bytes = self._recv_exact(sock, 8)
+        (recv_id,) = struct.unpack(">Q", id_bytes)
+        if recv_id != payload_id:
+            raise InvalidAckException()

--- a/pycernan/avro/client.py
+++ b/pycernan/avro/client.py
@@ -12,7 +12,6 @@ from queue import Queue, Empty
 from pycernan.avro.exceptions import EmptyBatchException, EmptyPoolException
 from pycernan.avro.serde import serialize
 
-
 _DefunctConnection = object()
 
 
@@ -27,6 +26,7 @@ class TCPConnectionPool(object):
     more intelligent to handle connection related exceptions distinct from application layer
     concerns.
     """
+
     def __init__(self, host, port, maxsize, connect_timeout, read_timeout):
         if maxsize <= 0:
             raise ValueError("maxsize must be > 0")

--- a/pycernan/avro/v2.py
+++ b/pycernan/avro/v2.py
@@ -1,0 +1,82 @@
+"""
+    V2 Client for Cernan's Avro source.
+"""
+import struct
+
+from pycernan.avro.base_client import BaseClient, _hash_u64, _rand_u64
+
+
+class Client(BaseClient):
+    """
+       V2 of the Avro source protocol.
+    """
+
+    VERSION = 2
+
+    def publish_blob(self, avro_blob, sync=True, payload_id=None, shard_by=None, metadata=None):
+        """
+            Publishes a length prefixed Avro payload to a V2 Avro source.
+
+            Diagram below describes packet layout.
+
+             0                   1                   2                   3
+             0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                             Length                            |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                            Version                            |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                            Control                            |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                                                               |
+            +                               ID                              +
+            |                                                               |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                                                               |
+            +                            ShardBy                            +
+            |                                                               |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |   #KV Pairs   |   Key Length  |    Key (up to 255 bytes)      |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |          Value Length         |   Value (up to 65535 bytes)   |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                          Avro N Bytes                         |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+            The fields of the payload have the following semantic meaning:
+
+            * Length  - Length of full packet
+            * Version - Version of the wire protocol used.  In this case, 2.
+            * Control - Metadata governing on the payload is to be published.
+                        Version 1 & 2 of the protocol only supports a bit indicating
+                        whether or not the client expects an ack after publication.
+            * ID - Explained in kwargs.
+            * ShardBy - Explained in kwargs.
+            * #KV Pairs - Number of KV pairs (max 255)
+            * Key Length - Length of Key in bytes (max 255)
+            * Key - N Bytes of Key data encoded as UTF-8 (max 255 bytes after encoding)
+            * Value Length - Length of Value data (max 65535)
+            * Value - N Bytes of Value data, no encoding enforced (max 65535 bytes)
+
+
+            Kwargs:
+                sync : bool - Wait for acknowledgment that the payload has been published?  Default = True.
+                id : int - Optional identifier for the payload.
+                shard_by : hashable value - Used to allocate the payload into a downstream bucket
+                           (order is only preserved between entries allocated to the same bucket).
+        """
+        version = self.VERSION
+        sync = 1 if sync else 0
+        payload_id = int(payload_id) if payload_id else _rand_u64()
+        shard_by = _hash_u64(shard_by) if shard_by else _rand_u64()
+        header = struct.pack(">LLQQ", version, sync, payload_id, shard_by)
+        metadata = metadata if metadata else {}
+        kv_encoded = struct.pack(">B", len(metadata))
+        for key, val in metadata.items():
+            kv_encoded += struct.pack(">B", len(key)) + key.encode("utf-8") + \
+                          struct.pack(">H", len(val)) + val.encode("utf-8")
+        payload_len = len(header) + len(kv_encoded) + len(avro_blob)
+        payload = struct.pack(">L", payload_len) + header + kv_encoded + avro_blob
+
+        self._send(payload_id, sync, payload)

--- a/tests/unit/avro/test_base_client.py
+++ b/tests/unit/avro/test_base_client.py
@@ -1,0 +1,72 @@
+import random
+import struct
+
+import mock
+import pytest
+
+from pycernan.avro.base_client import BaseClient
+from pycernan.avro.exceptions import InvalidAckException, ConnectionResetException
+
+
+class BinaryDummyClient(BaseClient):
+    def publish_blob(self, avro_blob, **kwargs):
+        pass
+
+    def _connect(self, host, port):
+        return mock.MagicMock()
+
+
+@pytest.fixture
+def dummy_client():
+    return BinaryDummyClient()
+
+
+@mock.patch('pycernan.avro.base_client.BaseClient._recv_exact', autospec=True)
+def test_wait_for_ack_raises_InvalidAckException_for_wrong_id_success_otherwise(m_recv, dummy_client):
+    mock_sock = mock.MagicMock()
+    expected_id = random.randrange(2 ** 64)
+    m_recv.return_value = struct.pack('>Q', expected_id)
+
+    with pytest.raises(InvalidAckException):
+        dummy_client._wait_for_ack(mock_sock, expected_id + 1)
+
+    dummy_client._wait_for_ack(mock_sock, expected_id)
+
+
+def test_send_exact_just_calls_sendall(dummy_client):
+    mock_sock = mock.MagicMock()
+    dummy_client._send_exact(mock_sock, b'some buffer')
+    assert mock_sock.sendall.call_args_list == [mock.call(b'some buffer')]
+
+
+def test_recv_exact_can_exit_after_one_iteration(dummy_client):
+    mock_sock = mock.MagicMock()
+    expected_data = b'all the data'
+    mock_sock.recv.return_value = expected_data
+    assert dummy_client._recv_exact(mock_sock, len(expected_data)) == expected_data
+
+
+def test_recv_exact_will_loop_if_necessary(dummy_client):
+    import sys
+    mock_sock = mock.MagicMock()
+    expected_data = b'all the data'
+
+    if sys.version_info >= (3, 0):
+        def make_side_effect():
+            return [bytearray(chr(b), encoding='utf8') for b in expected_data]
+    else:
+        def make_side_effect():
+            return [bytearray(b) for b in expected_data]
+
+    mock_sock.recv.side_effect = make_side_effect()
+    assert dummy_client._recv_exact(mock_sock, len(expected_data)) == expected_data
+
+    expected_recv_calls = [mock.call(x) for x in reversed(range(1, len(expected_data) + 1))]
+    assert mock_sock.recv.call_args_list == expected_recv_calls
+
+
+def test_recv_exact_with_zero_length_will_raise_ConnectionResetException(dummy_client):
+    mock_sock = mock.MagicMock()
+    mock_sock.recv.side_effect = [bytearray(0)]
+    with pytest.raises(ConnectionResetException):
+        dummy_client._recv_exact(mock_sock, 5)

--- a/tests/unit/avro/test_v1.py
+++ b/tests/unit/avro/test_v1.py
@@ -5,54 +5,45 @@ import mock
 import pytest
 
 import settings
-from pycernan.avro.v1 import Client, _hash_u64
-from pycernan.avro.exceptions import InvalidAckException, ConnectionResetException
 
-
-class V1DummyClient(Client):
-    def _connect(self, host, port):
-        return mock.MagicMock()
-
-
-@pytest.fixture
-def dummy_client():
-    return V1DummyClient()
+from pycernan.avro.base_client import _hash_u64
+from pycernan.avro.v1 import Client
 
 
 def unpack_fmt(nbytes):
     return ">LLLQQ{}s".format(nbytes)
 
 
-def random_id():
-    return random.choice([None, random.randrange(2**64)])
+def random_payload_id():
+    return random.choice([None, random.randrange(2 ** 64)])
 
 
 def random_shard_by():
-    return random.choice([None, random.randrange(2**64)])
+    return random.choice([None, random.randrange(2 ** 64)])
 
 
 def test_params():
     return [
-        (random_id(), random_shard_by(), test_file) for test_file in settings.test_data]
+        (random_payload_id(), random_shard_by(), test_file) for test_file in settings.test_data]
 
 
-@pytest.mark.parametrize("id, shard_by, avro_file", test_params())
+@pytest.mark.parametrize("payload_id, shard_by, avro_file", test_params())
 @mock.patch('pycernan.avro.client.TCPConnectionPool.connection', return_value=mock.MagicMock(), autospec=True)
 @mock.patch('pycernan.avro.v1.Client._wait_for_ack', return_value=None, autospec=True)
 @mock.patch('pycernan.avro.v1.Client._send_exact', return_value=None, autospec=True)
-def test_publish_blob(send_mock, ack_mock, connect_mock, id, shard_by, avro_file):
+def test_publish_blob(send_mock, ack_mock, _, payload_id, shard_by, avro_file):
     c = Client()
 
     with open(avro_file, 'rb') as file:
         file_contents = file.read()
 
-    if id:
-        ack_mock.return_value = struct.pack(">Q", id)
+    if payload_id:
+        ack_mock.return_value = struct.pack(">Q", payload_id)
 
-    sync = id is not None
-    c.publish_blob(file_contents, sync=sync, id=id, shard_by=shard_by)
+    sync = payload_id is not None
+    c.publish_blob(file_contents, sync=sync, payload_id=payload_id, shard_by=shard_by)
     send_calls = send_mock.mock_calls
-    assert(len(send_calls) == 1)
+    assert (len(send_calls) == 1)
     send_call = send_calls[0]
     (_self, _sock, payload_raw) = send_call[1]
 
@@ -60,69 +51,18 @@ def test_publish_blob(send_mock, ack_mock, connect_mock, id, shard_by, avro_file
         unpack_fmt(len(file_contents)),
         payload_raw)
 
-    assert((len(payload_raw) - 4) == payload[0])  # Length of the binary blob
-    assert(payload[1] == 1)  # Version number
-    assert(payload[2] == (1 if sync else 0))  # Control
+    assert ((len(payload_raw) - 4) == payload[0])  # Length of the binary blob
+    assert (payload[1] == 1)  # Version number
+    assert (payload[2] == (1 if sync else 0))  # Control
 
-    if id:
-        assert(payload[3] == id)
+    if payload_id:
+        assert (payload[3] == payload_id)
 
     if shard_by:
-        assert(payload[4] == _hash_u64(shard_by))
+        assert (payload[4] == _hash_u64(shard_by))
 
     # Payload contents should match the avro we sent.
-    assert(payload[5] == file_contents)
+    assert (payload[5] == file_contents)
 
-    if id:
-        assert(len(ack_mock.mock_calls) == 1)
-
-
-@mock.patch('pycernan.avro.v1.Client._recv_exact', autospec=True)
-def test_wait_for_ack_raises_InvalidAckException_for_wrong_id_success_otherwise(m_recv, dummy_client):
-    mock_sock = mock.MagicMock()
-    expected_id = random.randrange(2**64)
-    m_recv.return_value = struct.pack('>Q', expected_id)
-
-    with pytest.raises(InvalidAckException):
-        dummy_client._wait_for_ack(mock_sock, expected_id+1)
-
-    dummy_client._wait_for_ack(mock_sock, expected_id)
-
-
-def test_send_exact_just_calls_sendall(dummy_client):
-    mock_sock = mock.MagicMock()
-    dummy_client._send_exact(mock_sock, b'some buffer')
-    assert mock_sock.sendall.call_args_list == [mock.call(b'some buffer')]
-
-
-def test_recv_exact_can_exit_after_one_iteration(dummy_client):
-    mock_sock = mock.MagicMock()
-    expected_data = b'all the data'
-    mock_sock.recv.return_value = expected_data
-    dummy_client._recv_exact(mock_sock, len(expected_data)) == expected_data
-
-
-def test_recv_exact_will_loop_if_necessary(dummy_client):
-    import sys
-    mock_sock = mock.MagicMock()
-    expected_data = b'all the data'
-
-    if sys.version_info >= (3, 0):
-        def make_side_effect():
-            return [bytearray(chr(b), encoding='utf8') for b in expected_data]
-    else:
-        def make_side_effect():
-            return [bytearray(b) for b in expected_data]
-
-    mock_sock.recv.side_effect = make_side_effect()
-    assert dummy_client._recv_exact(mock_sock, len(expected_data)) == expected_data
-
-    expected_recv_calls = [mock.call(x) for x in reversed(range(1, len(expected_data)+1))]
-    assert mock_sock.recv.call_args_list == expected_recv_calls
-
-
-def test_recv_exact_with_zero_length_will_raise_ConnectionResetException(dummy_client):
-    mock_sock = mock.MagicMock()
-    mock_sock.recv.side_effect = [bytearray(0)]
-    with pytest.raises(ConnectionResetException):
-        dummy_client._recv_exact(mock_sock, 5)
+    if payload_id:
+        assert (len(ack_mock.mock_calls) == 1)

--- a/tests/unit/avro/test_v2.py
+++ b/tests/unit/avro/test_v2.py
@@ -1,0 +1,98 @@
+import io
+import random
+import string
+import struct
+
+import mock
+import pytest
+
+import settings
+from pycernan.avro.base_client import _hash_u64
+from pycernan.avro.v2 import Client
+
+HEADER_FMT = ">LLLQQ"
+METADATA_ENTRIES_FMT = ">B"
+KEY_LEN_FMT = ">B"
+VAL_LEN_FMT = ">H"
+
+
+def read_unpack(reader, fmt):
+    raw = reader.read(struct.calcsize(fmt))
+    return struct.unpack(fmt, raw)
+
+
+def random_string(length):
+    return ''.join([random.choice(string.ascii_letters) for _ in range(length)])
+
+
+def random_payload_id():
+    return random.choice([None, random.randrange(2 ** 64)])
+
+
+def random_shard_by():
+    return random.choice([None, random.randrange(2 ** 64)])
+
+
+def random_metadata():
+    return random.choice([None, {random_string(random.randrange(2 ** 8)): random_string(random.randrange(2 ** 16))}])
+
+
+def test_params():
+    return [
+        (random_payload_id(), random_shard_by(), test_file, random_metadata()) for test_file in settings.test_data]
+
+
+@pytest.mark.parametrize("payload_id, shard_by, avro_file, metadata", test_params())
+@mock.patch('pycernan.avro.client.TCPConnectionPool.connection', return_value=mock.MagicMock(), autospec=True)
+@mock.patch('pycernan.avro.v2.Client._wait_for_ack', return_value=None, autospec=True)
+@mock.patch('pycernan.avro.v2.Client._send_exact', return_value=None, autospec=True)
+def test_publish_blob(send_mock, ack_mock, _, payload_id, shard_by, avro_file, metadata):
+    c = Client()
+
+    with open(avro_file, 'rb') as file:
+        file_contents = file.read()
+
+    if payload_id:
+        ack_mock.return_value = struct.pack(">Q", payload_id)
+
+    sync = payload_id is not None
+    c.publish_blob(file_contents, sync=sync, payload_id=payload_id, shard_by=shard_by, metadata=metadata)
+    send_calls = send_mock.mock_calls
+    assert (len(send_calls) == 1)
+    send_call = send_calls[0]
+    (_self, _sock, payload_raw) = send_call[1]
+
+    payload_reader = io.BytesIO(payload_raw)
+
+    header = read_unpack(payload_reader, HEADER_FMT)
+
+    assert ((len(payload_raw) - 4) == header[0])  # Length of the binary blob
+    assert (header[1] == 2)  # Version number
+    assert (header[2] == (1 if sync else 0))  # Control
+
+    if payload_id:
+        assert (header[3] == payload_id)
+
+    if shard_by:
+        assert (header[4] == _hash_u64(shard_by))
+
+    metadata_entries = read_unpack(payload_reader, METADATA_ENTRIES_FMT)[0]
+
+    expected_metadata_entries = len(metadata) if metadata else 0
+    assert metadata_entries == expected_metadata_entries
+
+    decoded_metadata = {}
+    for i in range(metadata_entries):
+        key_len = read_unpack(payload_reader, KEY_LEN_FMT)[0]
+        key = payload_reader.read(key_len)
+        val_len = read_unpack(payload_reader, VAL_LEN_FMT)[0]
+        val = payload_reader.read(val_len)
+        decoded_metadata[key] = val
+
+    payload_contents = payload_reader.read()
+
+    # Payload contents should match the avro we sent.
+    assert (payload_contents == file_contents)
+
+    if payload_id:
+        assert (len(ack_mock.mock_calls) == 1)


### PR DESCRIPTION
The protocol allows up to 255 key value pairs, each with a
key of up to 255 UTF-8 encoded bytes and a value of up to 65535 bytes in
length.

The new packet structure is described below in IETF RFC format:

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                             Length                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                            Version                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                            Control                            |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                                                               |
+                               ID                              +
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                                                               |
+                            ShardBy                            +
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|   #KV Pairs   |   Key Length  |    Key (up to 255 bytes)      |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|          Value Length         |   Value (up to 65535 bytes)   |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                          Avro N Bytes                         |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

The source remains backwards compatible with version 1 clients.