### PR TITLE
Enable write time validation

### DIFF
--- a/pycernan/avro/exceptions.py
+++ b/pycernan/avro/exceptions.py
@@ -3,7 +3,10 @@ import fastavro
 SchemaParseException = (fastavro.schema.SchemaParseException, KeyError)
 SchemaResolutionException = fastavro.read.SchemaResolutionError
 UnknownTypeException = fastavro.schema.UnknownType
-DatumTypeException = ValueError
+
+
+class DatumTypeException(Exception):
+    pass
 
 
 class EmptyBatchException(Exception):

--- a/pycernan/avro/serde.py
+++ b/pycernan/avro/serde.py
@@ -3,6 +3,7 @@ import sys
 import types
 
 from fastavro import reader, writer, parse_schema
+from fastavro.validation import ValidationError
 from io import BytesIO, IOBase
 
 from pycernan.avro.exceptions import DatumTypeException
@@ -44,8 +45,8 @@ def serialize(schema_map, batch, ephemeral_storage=False, **metadata):
             # Fast avro doesn't handle iterators within iterators gracefully..
             write_data = record_or_generator
         try:
-            writer(avro_buf, parsed_schema, write_data, codec='deflate', metadata=metadata)
-        except (ValueError, TypeError) as e:
+            writer(avro_buf, parsed_schema, write_data, codec='deflate', metadata=metadata, validator=True)
+        except (ValueError, TypeError, ValidationError) as e:
             raise DatumTypeException(e)
 
     return avro_buf.getvalue()

--- a/tests/unit/avro/test_serde.py
+++ b/tests/unit/avro/test_serde.py
@@ -77,6 +77,24 @@ def test_serialize_bad_datum_empty():
     with pytest.raises(DatumTypeException):
         serialize(USER_SCHEMA, [user])
 
+def test_serialize_bad_type_for_field():
+    user = {
+        'name': 'Foo Bar Matic',
+        'favorite_number': "Not an int",
+        'favorite_color': 'Nonyabusiness',
+    }
+    with pytest.raises(DatumTypeException):
+        serialize(USER_SCHEMA, [user])
+
+def test_serialize_bad_missing_required_field():
+    # Field "name" is required but missing
+    user = {
+        'favorite_number': "Not an int",
+        'favorite_color': 'Nonyabusiness',
+    }
+    with pytest.raises(DatumTypeException):
+        serialize(USER_SCHEMA, [user])
+
 
 @pytest.mark.parametrize('schema', [USER_SCHEMA, parse_schema(USER_SCHEMA)])
 @pytest.mark.parametrize('ephemeral', [True, False])


### PR DESCRIPTION
When writing events we would like to verify types etc to ensure data integrity.