### PR TITLE
Split out TCPConnectionPool and add metrics

### DIFF
--- a/pycernan/avro/base_client.py
+++ b/pycernan/avro/base_client.py
@@ -3,7 +3,9 @@ import struct
 
 from pycernan.avro.client import Client
 from pycernan.avro.exceptions import ConnectionResetException, InvalidAckException
+from pycernan.avro import metrics
 
+NUM_ID_BYTES = 8
 
 def _hash_u64(value):
     return hash(value) % 2 ** 64
@@ -15,7 +17,10 @@ def _rand_u64():
 
 class BaseClient(Client):
     def _send_exact(self, sock, payload):
-        sock.sendall(payload)
+        metrics.bytes_sent.inc(len(payload))
+        metrics.event_size_bytes.observe(len(payload))
+        with metrics.publish_latency.time():
+            sock.sendall(payload)
 
     def _recv_exact(self, sock, n_bytes):
         buf = bytearray(b'')
@@ -30,12 +35,18 @@ class BaseClient(Client):
 
     def _send(self, payload_id, sync, payload):
         with self.pool.connection() as sock:
+            metrics.publish_count.inc()
             self._send_exact(sock, payload)
             if sync:
-                self._wait_for_ack(sock, payload_id)
+                metrics.ack_request_count.inc()
+                with metrics.ack_latency.time():
+                    self._wait_for_ack(sock, payload_id)
+                metrics.ack_count.inc()
 
     def _wait_for_ack(self, sock, payload_id):
-        id_bytes = self._recv_exact(sock, 8)
+        id_bytes = self._recv_exact(sock, NUM_ID_BYTES)
+        metrics.bytes_received.inc(len(id_bytes))
         (recv_id,) = struct.unpack(">Q", id_bytes)
         if recv_id != payload_id:
+            metrics.ack_invalid_count.inc()
             raise InvalidAckException()

--- a/pycernan/avro/client.py
+++ b/pycernan/avro/client.py
@@ -1,113 +1,15 @@
 """
     Base Avro client from which all other clients derive.
 """
-import contextlib
-import socket
 
 import pycernan.avro.config
 
 from abc import ABCMeta, abstractmethod
-from queue import Queue, Empty
 
-from pycernan.avro.exceptions import EmptyBatchException, EmptyPoolException
+from pycernan.avro.exceptions import EmptyBatchException
 from pycernan.avro.serde import serialize
-
-_DefunctConnection = object()
-
-
-class TCPConnectionPool(object):
-    """
-    Fork friendly TCP connection pool.
-
-    Adapted from: https://github.com/gevent/gevent/blob/master/examples/psycopg2_pool.py
-
-    All exceptions (application, operation (timeouts, etc)) are the responsibility of the user to
-    handle responsibly.  One day, with sufficient time and motivation, this class could be made
-    more intelligent to handle connection related exceptions distinct from application layer
-    concerns.
-    """
-
-    def __init__(self, host, port, maxsize, connect_timeout, read_timeout):
-        if maxsize <= 0:
-            raise ValueError("maxsize must be > 0")
-
-        self.host = host
-        self.port = port
-        self.maxsize = maxsize
-
-        self.connect_timeout = connect_timeout
-        self.read_timeout = read_timeout
-        self.pool = Queue()
-        for _ in range(maxsize):
-            self._put(_DefunctConnection)
-
-    def _create_connection(self):
-        sock = socket.create_connection((self.host, self.port), timeout=self.connect_timeout)
-        sock.settimeout(self.read_timeout)
-        return sock
-
-    def _get(self, _block=True):
-        try:
-            connection = self.pool.get(_block)
-        except Empty:
-            # Expected to happen only when users override _block=False
-            raise EmptyPoolException()
-
-        # When a connection is defunct, we attempt to
-        # regenerate it.  Note - it is important that we always return
-        # something back to the queue here so that we don't errode our capacity.
-        if connection is _DefunctConnection:
-            try:
-                connection = self._create_connection()
-            except:
-                # Always return a resource to the queue,
-                # even if it is defunct.
-                self._put(_DefunctConnection)
-                raise
-
-        return connection
-
-    def _put(self, item):
-        # Why this function?  It makes mocking in unit tests easier.
-        self.pool.put(item)
-
-    def closeall(self):
-        """
-            Close established connections currently not in-use.
-        """
-        try:
-            while True:
-                conn = self.pool.get_nowait()
-                if conn is _DefunctConnection:
-                    continue
-                conn.close()
-        except Exception:
-            pass
-
-    @contextlib.contextmanager
-    def connection(self, _block=True):
-        """
-            Context manager for pooled connections.
-        """
-        garbage = None
-        conn = self._get(_block)
-        try:
-            yield conn
-        except:
-            # Why do we defer closing conn here?
-            # Python2 has different `raise` semantics than Python3.
-            # Deferring garbage collection until the finally block
-            # saves us from having to account for these differences.
-            garbage = conn
-            conn = _DefunctConnection
-            raise
-        finally:
-            if garbage:
-                try:
-                    garbage.close()
-                except:
-                    pass
-            self._put(conn)
+from pycernan.avro import metrics
+from pycernan.avro.tcp_conn_pool import TCPConnectionPool
 
 
 class Client(object):
@@ -136,6 +38,7 @@ class Client(object):
         """
         self.pool.closeall()
 
+    @metrics.publish_failure_count.count_exceptions()
     def publish(self, schema_map, batch, ephemeral_storage=False, **kwargs):
         """
             Publishes a batch of records corresponding to the given schema.

--- a/pycernan/avro/metrics.py
+++ b/pycernan/avro/metrics.py
@@ -1,0 +1,30 @@
+from prometheus_client.metrics import Counter, Histogram
+
+PREFIX = "pycernan"
+
+
+def p(n):
+    return PREFIX + "_" + n
+
+
+# Generates buckets ranging from 64 bytes to 1MB, in powers of 2
+SIZE_BUCKETS = [2 ** i for i in range(6, 21)]
+
+ack_count = Counter(p('ack_count'), "Number of acknowledgements received.")
+ack_invalid_count = Counter(p('ack_invalid_count'), "Number of invalid acknowledgements received.")
+ack_latency = Histogram(p('ack_latency'), "Acknowledgement latency in seconds.")
+ack_request_count = Counter(p('ack_request_count'), "Number of acknowledgements requested.")
+
+bytes_sent = Counter(p('bytes_sent'), "Total bytes sent.")
+bytes_received = Counter(p('bytes_recv'), "Total bytes received.")
+
+conn_create_count = Counter(p('conn_create_count'), "Number of connections established by connection pool.")
+conn_close_count = Counter(p('conn_close_count'), "Number of connections closed by connection pool.")
+conn_failure_count = Counter(p('conn_failure_count'), "Number of failures to yield a connection from the pool.")
+conn_acquire_latency = Histogram(p('conn_acquire_count'), "Connection acquisition latency")
+
+event_size_bytes = Histogram(p('event_size_bytes'), "Histogram of event sizes in bytes", buckets=SIZE_BUCKETS)
+
+publish_count = Counter(p('publish_count'), "Number of events published.")
+publish_failure_count = Counter(p('publish_failure_count'), "Number of events that failed to publish successfully.")
+publish_latency = Histogram(p('publish_latency'), "Publish latency in seconds.")

--- a/pycernan/avro/tcp_conn_pool.py
+++ b/pycernan/avro/tcp_conn_pool.py
@@ -1,0 +1,106 @@
+import contextlib
+import socket
+from queue import Queue, Empty
+
+from pycernan.avro.exceptions import EmptyPoolException
+from pycernan.avro import metrics
+
+_DefunctConnection = object()
+
+
+class TCPConnectionPool(object):
+    """
+    Fork friendly TCP connection pool.
+
+    Adapted from: https://github.com/gevent/gevent/blob/master/examples/psycopg2_pool.py
+
+    All exceptions (application, operation (timeouts, etc)) are the responsibility of the user to
+    handle responsibly.  One day, with sufficient time and motivation, this class could be made
+    more intelligent to handle connection related exceptions distinct from application layer
+    concerns.
+    """
+
+    def __init__(self, host, port, maxsize, connect_timeout, read_timeout):
+        if maxsize <= 0:
+            raise ValueError("maxsize must be > 0")
+
+        self.host = host
+        self.port = port
+        self.maxsize = maxsize
+
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.pool = Queue()
+        for _ in range(maxsize):
+            self._put(_DefunctConnection)
+
+    def _create_connection(self):
+        metrics.conn_create_count.inc()
+        sock = socket.create_connection((self.host, self.port), timeout=self.connect_timeout)
+        sock.settimeout(self.read_timeout)
+        return sock
+
+    def _get(self, _block=True):
+        try:
+            connection = self.pool.get(_block)
+        except Empty:
+            # Expected to happen only when users override _block=False
+            raise EmptyPoolException()
+
+        # When a connection is defunct, we attempt to
+        # regenerate it.  Note - it is important that we always return
+        # something back to the queue here so that we don't erode our capacity.
+        if connection is _DefunctConnection:
+            try:
+                connection = self._create_connection()
+            except Exception:
+                # Always return a resource to the queue,
+                # even if it is defunct.
+                self._put(_DefunctConnection)
+                raise
+
+        return connection
+
+    def _put(self, item):
+        # Why this function?  It makes mocking in unit tests easier.
+        self.pool.put(item)
+
+    def closeall(self):
+        """
+            Close established connections currently not in-use.
+        """
+        try:
+            while True:
+                conn = self.pool.get_nowait()
+                if conn is _DefunctConnection:
+                    continue
+                conn.close()
+        except Exception:
+            pass
+
+    @contextlib.contextmanager
+    def connection(self, _block=True):
+        """
+            Context manager for pooled connections.
+        """
+        garbage = None
+        conn = self._get(_block)
+        try:
+            yield conn
+        except Exception:
+            # Why do we defer closing conn here?
+            # Python2 has different `raise` semantics than Python3.
+            # Deferring garbage collection until the finally block
+            # saves us from having to account for these differences.
+            garbage = conn
+            conn = _DefunctConnection
+            metrics.conn_failure_count.inc()
+            raise
+        finally:
+            if garbage:
+                try:
+                    garbage.close()
+                    metrics.conn_close_count.inc()
+                except Exception:
+                    pass
+            self._put(conn)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 from pycernan import __version__
 
-install_requires = ['fastavro', 'future']
+install_requires = ['fastavro', 'future', 'prometheus_client']
 
 setup(
     name="pycernan",


### PR DESCRIPTION
Move TCPConnectionPool to it's own file as it's not really coupled to Client.
Add prometheus metrics for publishes, acks and connection handling.